### PR TITLE
Add support for --token-usage/-t flag to display token information

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,11 @@ Creates the file, specified by user and writes the result there. It is highly re
 ./polyglot <file> <language> --output file.txt
 ```
 
+### Token information
+
+Displays token information, including input token number and output token number. Usage:
+
+```bash
+./polyglot <file> <language> -t
+./polyglot <file> <language> --token-usage
+```

--- a/src/main/java/org/example/CohereApi.java
+++ b/src/main/java/org/example/CohereApi.java
@@ -11,12 +11,11 @@ public class CohereApi {
     // language - language to translate file in
     // api - api-key
     // baseURL - baseURL default or specified by user
-    public static String callApi(String content, String language, String api, String baseURL) throws Exception {
+    public static JSONObject callApi(String content, String language, String api, String baseURL) throws Exception {
 
         // Transform content into the JSON object
         String contentJson = JSONObject.quote(content);
 
-        String rawResponse = "";
         // Create a client that sends requests to the api
         OkHttpClient client = new OkHttpClient();
 
@@ -45,10 +44,7 @@ public class CohereApi {
         // otherwise throw an exception
         if (response.isSuccessful()) {
             String responseString = response.body().string();
-            JSONObject jsonObject = new JSONObject(responseString);
-            rawResponse = jsonObject.getString("text");
-//            System.out.println("\n" + rawResponse);
-            return rawResponse;
+            return new JSONObject(responseString);
         } else {
             throw new Exception("Request failed: " + response.code() + " :c");
         }

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -144,7 +144,8 @@ public class Main implements Callable<Integer> {
             System.err.println("\n------------------------\n" +
                     "Token Information:\n" +
                     "Input Tokens: " + inputTokens + "\n" +
-                    "Output Tokens: " + outputTokens);
+                    "Output Tokens: " + outputTokens + "\n" +
+                    "Total Tokens: " + (inputTokens + outputTokens));
         }
 
         return 1;

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -17,7 +17,6 @@ import java.util.List;
         description = "A command-line tool that helps to translate code in ANY programming language.",
         customSynopsis = "./polyglot <files>... <language> [OPTIONS]"
 )
-
 // Callable Main class
 public class Main implements Callable<Integer> {
 

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,5 +1,6 @@
 package org.example;
 
+import org.json.JSONObject;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
@@ -16,6 +17,13 @@ import java.util.List;
         description = "A command-line tool that helps to translate code in ANY programming language.",
         customSynopsis = "./polyglot <files>... <language> [OPTIONS]"
 )
+
+// Define a TokenInfo class
+class TokenInfo {
+    int inputTokens;
+    int outputTokens;
+}
+
 // Callable Main class
 public class Main implements Callable<Integer> {
 
@@ -64,6 +72,13 @@ public class Main implements Callable<Integer> {
     )
     private String baseURL;
 
+    // Flags -t && --token-usage to display token information
+    @Option(
+            names = {"-t", "--token-usage"},
+            description = "Display token information"
+    )
+    private boolean tokenUsage;
+
 
     // Function to be called in main file, using for picoCLI
     @Override
@@ -80,13 +95,17 @@ public class Main implements Callable<Integer> {
         Path projectPath = Paths.get("").toAbsolutePath();
         Path folderPath = Paths.get("examples");
 
+        // Declare a new TokenInfo
+        TokenInfo tokenInfo = new TokenInfo();
+
         // For-loop
         // Works until all files are translated
         for(int i = 0; i < fileNames.size(); i++) {
 
             System.out.println("Attempting to translate " + fileNames.get(i) + "...");
 
-            String result = "";
+            JSONObject resultJSON;
+            String resultText = "";
             String content = "";
 
             // Possible file paths to search for
@@ -107,8 +126,9 @@ public class Main implements Callable<Integer> {
 
             // Invokes callApi function from CohereApi class
             // assigns the output to the result string
-            result = CohereApi.callApi(content, language, api, baseURL);
-            System.out.println(GREEN + "After: \n" + RESET +  result);
+            resultJSON = CohereApi.callApi(content, language, api, baseURL);
+            resultText = resultJSON.getString("text");
+            System.out.println(GREEN + "After: \n" + RESET + resultText);
 
             // If user specified the output file
             // The result writes to the new file
@@ -116,9 +136,21 @@ public class Main implements Callable<Integer> {
             if (!outputFile.equals("")) {
                 Path outputPath = Path.of(projectPath + "//" + outputFile);
                 System.out.println("Output path is: " + outputPath);
-                Files.writeString(outputPath, result);
+                Files.writeString(outputPath, resultText);
             }
 
+            // Extract token information from resultJSON
+            tokenInfo.inputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("input_tokens");
+            tokenInfo.outputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("output_tokens");
+        }
+
+        // If -t option is present
+        // Output token information to stderr
+        if (tokenUsage) {
+            System.err.println("\n------------------------\n" +
+                    "Token Information:\n" +
+                    "Input Tokens: " + tokenInfo.inputTokens + "\n" +
+                    "Output Tokens: " + tokenInfo.outputTokens);
         }
 
         return 1;

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -18,12 +18,6 @@ import java.util.List;
         customSynopsis = "./polyglot <files>... <language> [OPTIONS]"
 )
 
-// Define a TokenInfo class
-class TokenInfo {
-    int inputTokens;
-    int outputTokens;
-}
-
 // Callable Main class
 public class Main implements Callable<Integer> {
 
@@ -95,8 +89,9 @@ public class Main implements Callable<Integer> {
         Path projectPath = Paths.get("").toAbsolutePath();
         Path folderPath = Paths.get("examples");
 
-        // Declare a new TokenInfo
-        TokenInfo tokenInfo = new TokenInfo();
+        // Declare tokens
+        int inputTokens = 0;
+        int outputTokens = 0;
 
         // For-loop
         // Works until all files are translated
@@ -140,8 +135,8 @@ public class Main implements Callable<Integer> {
             }
 
             // Extract token information from resultJSON
-            tokenInfo.inputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("input_tokens");
-            tokenInfo.outputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("output_tokens");
+            inputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("input_tokens");
+            outputTokens += resultJSON.getJSONObject("meta").getJSONObject("tokens").getInt("output_tokens");
         }
 
         // If -t option is present
@@ -149,8 +144,8 @@ public class Main implements Callable<Integer> {
         if (tokenUsage) {
             System.err.println("\n------------------------\n" +
                     "Token Information:\n" +
-                    "Input Tokens: " + tokenInfo.inputTokens + "\n" +
-                    "Output Tokens: " + tokenInfo.outputTokens);
+                    "Input Tokens: " + inputTokens + "\n" +
+                    "Output Tokens: " + outputTokens);
         }
 
         return 1;


### PR DESCRIPTION
This pull request fixes #5.

### Changes
- Function `callApi` returns `JSONObject` instead of `String`.
  - Since the program now needs more information from the API response, returning `String` won't be sufficient. Instead, the entire JSON object is returned. Data extraction is moved to the main function.
- Added local variables `inputTokens` and `outputTokens`.
  - Since the program supports multiple input files. This is needed to keep track of token information from all API calls combined.
 - Used `System.err.printil()` to output token information to `stderr`.
 - Updated `README.md` to include information of this new feature.